### PR TITLE
Fix a bug in nested relation evaluation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+Version 3.5 (2024-12-08)
+------------------------
+Bug Fixes
+---------
+   - Fix a bug where nested relations could not be evaluated when part of a sweep.
+
 Version 3.4 (2024-10-27)
 ------------------------
 

--- a/src/pyqsl/common.py
+++ b/src/pyqsl/common.py
@@ -334,14 +334,27 @@ def _evaluate_relation_with_sweeps(
 def _evaluate_relation_in_loop(
     setting_dict: dict[str, Any], relation, settings: Settings
 ):
-    parameter_dict = {
-        parameter_name: (
-            setting_dict[setting_name]
-            if setting_name in setting_dict
-            else settings[setting_name].value
-        )
-        for parameter_name, setting_name in relation.parameters.items()
-    }
+    parameter_dict = {}
+    for parameter_name, setting_name in relation.parameters.items():
+        if isinstance(setting_name, Relation):
+            parameter_dict[parameter_name] = _evaluate_relation_in_loop(
+                setting_dict, setting_name, settings
+            )
+        else:
+            parameter_dict[parameter_name] = (
+                setting_dict[setting_name]
+                if setting_name in setting_dict
+                else settings[setting_name].value
+            )
+
+    # parameter_dict = {
+    #     parameter_name: (
+    #         setting_dict[setting_name]
+    #         if setting_name in setting_dict
+    #         else settings[setting_name].value
+    #     )
+    #     for parameter_name, setting_name in relation.parameters.items()
+    # }
     return relation.evaluate(**parameter_dict)
 
 
@@ -448,3 +461,4 @@ def calculate_chunksize(n_cores: int, n_points: int) -> int:
 from pyqsl.many_to_many_relation import (  # pylint: disable=wrong-import-position
     EvaluatedManyToManyRelation,
 )
+from pyqsl.relation import Relation  # pylint: disable=wrong-import-position

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -192,11 +192,13 @@ def test_lookup_table_options(settings):
         settings.resolve_relations()
 
     fill_value = -0.1
-    settings.amplitude.relation.interpolation_options = {'fill_value': fill_value, "bounds_error": False}
+    settings.amplitude.relation.interpolation_options = {
+        "fill_value": fill_value,
+        "bounds_error": False,
+    }
     settings.resolve_relations()
     assert settings.amplitude.value == fill_value
-        
-    
+
 
 def test_nodes_with_relation_is_correct():
     settings = pyqsl.Settings()
@@ -251,6 +253,6 @@ def test_function():
 def test_errors_in_relations():
     settings = pyqsl.Settings()
     settings.a = 2
-    settings.b = pyqsl.Setting(relation='ab')
+    settings.b = pyqsl.Setting(relation="ab")
     with pytest.raises(KeyError):
         settings.resolve_relations()


### PR DESCRIPTION
Nested relation evaluation resulted in an error for sweeps. Fixed by checking for relations and evaluating them iteratively.